### PR TITLE
Added Border Irregularity Calculation for Improved Skin Lesion Anaylsis

### DIFF
--- a/model/handcrafted.ipynb
+++ b/model/handcrafted.ipynb
@@ -539,13 +539,39 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "81101cf6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def calculate_border_irregularity(contours):\n",
+    "    # Return some default or error value if no contours are found\n",
+    "    if not contours:\n",
+    "        return 0, 0 \n",
+    "    \n",
+    "    largest_contour = max(contours, key=cv2.contourArea)\n",
+    "    perimeter = cv2.arcLength(largest_contour, True)\n",
+    "    convex_hull = cv2.convexHull(largest_contour)\n",
+    "    hull_perimeter = cv2.arcLength(convex_hull, True)\n",
+    "    \n",
+    "    # Higher values indicate more irregularity\n",
+    "    irregularity = perimeter / hull_perimeter  \n",
+    "   \n",
+    "    return irregularity\n"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 91,
    "id": "7aa5f6ce-a8e9-4dd7-91f6-8b1c45660b35",
    "metadata": {},
    "outputs": [],
    "source": [
     "symmetry_value = calculate_symmetry()\n",
-    "symmetry_value = np.array([symmetry_value])"
+    "symmetry_value = np.array([symmetry_value])\n",
+    "\n",
+    "border_irregularity = calculate_border_irregularity(contours) \n",
+    "border_irregularity = np.array([border_irregularity])"
    ]
   },
   {
@@ -556,7 +582,7 @@
    "outputs": [],
    "source": [
     "handcrafted_features = np.concatenate([np.array([area, perimeter, circularity, diameter, eccentricity]),\n",
-    "                                        color_features, texture_features, symmetry_value])"
+    "                                        color_features, texture_features, symmetry_value, border_irregularity])"
    ]
   }
  ],


### PR DESCRIPTION
Why: Border irregularity is one of the key diagnostic criteria used in the evaluation of skin lesions as outlined in the ABCDE rule.
How it works: 
Used max(contours, key=cv2.contourArea) to identify the largest contour based on the area.
Used the cv2.arcLength function to calculate the perimeter of the largest contour, which is the outline of the lesion.
Calculated the convex hull of the largest contour with the cv2.convexHull function.
Used cv2.arcLength to calculate the perimeter of the convex hull.
Calculated the ratio of the perimeter of the largest contour to the perimeter of its convex hull.
-A higher ratio indicates a more irregular, potentially suspicious border.
Function returns the ratio as a numeric value which can be used as a feature in subsequent analysis.
Added the border irregularity return value to the set of handcrafted features